### PR TITLE
Add Development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,6 @@ A note for contributors.
 * Elixir/Erlang
 * PostgreSQL
 
-#### For macOS
-
-```
-$ brew install elixir postgresql
-$ brew services start postgresql
-```
-
 ### Install dependencies
 
 ```
@@ -35,38 +28,13 @@ $ mix deps.get
 $ npm i
 ```
 
-### Prepare database
+### Setup
 
-Prepare role and database for Share development.
-I assume you use a role `share_dev` with password `share_dev` and a database `share_dev`.
-
-```
-$ psql -U <username> -d postgres
-
-postgres=# CREATE ROLE share_dev WITH LOGIN SUPERUSER PASSWORD 'share_dev';
-CREATE ROLE
-postgres=# CREATE DATABASE share_dev;
-CREATE DATABASE
-postgres=# \q
-```
-
-Change `dev.exs` in `config` directory.
+Reference: [Installing Elixir & the Phoenix framework with Homebrew on OS X](https://gist.github.com/likethesky/abb00e5aedc38ee9f711).
 
 ```
-# Configure your database
-config :share, Share.Repo,
-  adapter: Ecto.Adapters.Postgres,
-  username: "share_dev",
-  password: "share_dev",
-  database: "share_dev",
-  hostname: "localhost",
-  pool_size: 10
-```
-
-Do migration.
-
-```
-$ mix ecto.migrate
+$ createuser -d postgres
+$ mix ecto.setup
 ```
 
 ### Start dev server

--- a/README.md
+++ b/README.md
@@ -10,3 +10,67 @@ Second, all posts don't have unique URLs.
 It is impossible to bookmark and share posts.
 
 You need to login to post, follow users, use personal timeline, and favorite posts.
+
+## Development
+
+A note for contributors.
+
+### Requirements
+
+* Node.js
+* Elixir/Erlang
+* PostgreSQL
+
+#### For macOS
+
+```
+$ brew install elixir postgresql
+$ brew services start postgresql
+```
+
+### Install dependencies
+
+```
+$ mix deps.get
+$ npm i
+```
+
+### Prepare database
+
+Prepare role and database for Share development.
+I assume you use a role `share_dev` with password `share_dev` and a database `share_dev`.
+
+```
+$ psql -U <username> -d postgres
+
+postgres=# CREATE ROLE share_dev WITH LOGIN SUPERUSER PASSWORD 'share_dev';
+CREATE ROLE
+postgres=# CREATE DATABASE share_dev;
+CREATE DATABASE
+postgres=# \q
+```
+
+Change `dev.exs` in `config` directory.
+
+```
+# Configure your database
+config :share, Share.Repo,
+  adapter: Ecto.Adapters.Postgres,
+  username: "share_dev",
+  password: "share_dev",
+  database: "share_dev",
+  hostname: "localhost",
+  pool_size: 10
+```
+
+Do migration.
+
+```
+$ mix ecto.migrate
+```
+
+### Start dev server
+
+```
+$ mix phoenix.start
+```


### PR DESCRIPTION
macOSでbrew経由でPostgreSQLをインストールすると初期ユーザがpostgresではなくログインユーザ名でした。現在のdev.exsのDBユーザ名はpostgresなのでエラーになる人もいるなぁと。
READMEでは専用のユーザを作るように指示してみましたが、そうするとgitのコミット時にdev.exsの変更点を無視しないといけなくて不便。

思い付いた解決方法としては２つ。

1. dev.exsを変更
2. dev.secret.exsに分ける
3. postgresユーザーを作る指示を追加